### PR TITLE
OLMIS-8058: fix the program field - stock on hand report

### DIFF
--- a/src/main/resources/db/migration/20250203112544180__fix_soh_program_picker.sql
+++ b/src/main/resources/db/migration/20250203112544180__fix_soh_program_picker.sql
@@ -1,0 +1,17 @@
+UPDATE
+    report.template_parameters
+SET
+    "datatype" = 'java.lang.String',
+    defaultvalue = NULL,
+    description = NULL,
+    displayname = 'Program',
+    "name" = 'program',
+    selectexpression = '/api/programs',
+    selectproperty = 'name',
+    displayproperty = 'name',
+    required = false,
+    templateid = '1fd4208c-6840-4925-a1f6-5770e8fb3e97',
+    selectmethod = NULL,
+    selectbody = NULL
+WHERE
+    id = '551795e8-5777-49c4-8e0c-b76bd65f8aed';


### PR DESCRIPTION
[OLMIS-8058](https://openlmis.atlassian.net/browse/OLMIS-8058)

Changes:
- Change the `selectproperty` from `id` to `name` (Program picker).

[OLMIS-8058]: https://openlmis.atlassian.net/browse/OLMIS-8058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ